### PR TITLE
ppsspp / lr-ppsspp - switch to v1.12.3 (last tagged version)

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -13,7 +13,7 @@ rp_module_id="ppsspp"
 rp_module_desc="PlayStation Portable emulator PPSSPP"
 rp_module_help="ROM Extensions: .iso .pbp .cso\n\nCopy your PlayStation Portable roms to $romdir/psp"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/hrydgard/ppsspp/master/LICENSE.TXT"
-rp_module_repo="git https://github.com/hrydgard/ppsspp.git master"
+rp_module_repo="git https://github.com/hrydgard/ppsspp.git v1.12.3"
 rp_module_section="opt"
 rp_module_flags=""
 

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-ppsspp"
 rp_module_desc="PlayStation Portable emu - PPSSPP port for libretro"
 rp_module_help="ROM Extensions: .iso .pbp .cso\n\nCopy your PlayStation Portable roms to $romdir/psp"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/ppsspp/master/LICENSE.TXT"
-rp_module_repo="git https://github.com/hrydgard/ppsspp.git master"
+rp_module_repo="git https://github.com/hrydgard/ppsspp.git v1.12.3"
 rp_module_section="opt"
 rp_module_flags=""
 


### PR DESCRIPTION
Current master has shader issues on videocore causing a black screen, so switching back to last tagged version - v1.12.3.

Historically we have had to fix up a fair number of ppsspp issues on the RPI due to upstream changes so sticking to a stable release seems like a good idea and allows us to test before we update.

The PPSSPP repository is also quite active and re-building ppsspp/lr-ppsspp binaries for every change takes a lot of time, so this also frees up some cpu time on our build system.