### PR TITLE
packages - fix update check due to security warning with git 2.34.1

### DIFF
--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -643,7 +643,7 @@ function rp_hasNewerModule() {
                 local vendor="${__mod_info[$id/vendor]}"
                 local repo_dir="$scriptdir"
                 [[ "$vendor" != "RetroPie" ]] && repo_dir+="/ext/$vendor"
-                local module_date="$(git -C "$repo_dir" log -1 --format=%cI -- "${__mod_info[$id/path]}")"
+                local module_date="$(sudo -u "$user" git -C "$repo_dir" log -1 --format=%cI -- "${__mod_info[$id/path]}")"
                 if rp_dateIsNewer "$pkg_date" "$module_date"; then
                     ret=0
                 fi


### PR DESCRIPTION
As with e041a0c5 we need to use the same user for running git as the owner of the repository files.

This is also needed for an update check in rp_hasNewerModule as we check the last commit date of scriptmodules in RetroPie-Setup.